### PR TITLE
GraphQL schema customisations

### DIFF
--- a/AsyncyPlugin.js
+++ b/AsyncyPlugin.js
@@ -16,6 +16,15 @@ module.exports = function AsyncyPlugin(builder) {
         }
       },
 
+      // Pluralize AppDns correctly
+      pluralize(string) {
+        if (string.match(/dns$/i)) {
+          return string + 'es';
+        } else {
+          return inflection.pluralize(string);
+        }
+      },
+
       // This removes the 'ByFooIdAndBarId' from the end of relations.
       //
       // If this causes a conflict, use smart comments:

--- a/AsyncyPlugin.js
+++ b/AsyncyPlugin.js
@@ -1,0 +1,57 @@
+/*
+ * This file contains some customisations over the default PostGraphile.
+ */
+module.exports = function AsyncyPlugin(builder) {
+  builder.hook("inflection", (inflection, build) => {
+    return {
+      ...inflection,
+
+      // Don't turn 'AppDns' into 'AppDn'
+      _singularizedTableName(table) {
+        const tableName = this._tableName(table);
+        if (tableName.match(/dns$/i)) {
+          return tableName;
+        } else {
+          return inflection._singularizedTableName(table);
+        }
+      },
+
+      // This removes the 'ByFooIdAndBarId' from the end of relations.
+      //
+      // If this causes a conflict, use smart comments:
+      //
+      //   https://www.graphile.org/postgraphile/smart-comments/#renaming
+      //
+      // to rename the relation.
+      singleRelationByKeys(detailedKeys, table, _foreignTable, constraint) {
+        if (constraint.tags.fieldName) {
+          return constraint.tags.fieldName;
+        }
+        return this.camelCase(
+          `${this._singularizedTableName(table)}`
+        );
+      },
+      manyRelationByKeys(detailedKeys, table, _foreignTable, constraint) {
+        if (constraint.tags.foreignFieldName) {
+          return constraint.tags.foreignFieldName;
+        }
+        return this.camelCase(
+          `${this.pluralize(
+            this._singularizedTableName(table)
+          )}`
+        );
+      },
+      manyRelationByKeysSimple(detailedKeys, table, _foreignTable, constraint) {
+        if (constraint.tags.foreignFieldName) {
+          return constraint.tags.foreignFieldName;
+        }
+        return this.camelCase(
+          `${this.pluralize(
+            this._singularizedTableName(table)
+          )}`
+        );
+      },
+
+    };
+  });
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
-FROM          node:alpine
+FROM          graphile/postgraphile
 
-RUN           npm install -g postgraphile
+COPY          ./AsyncyPlugin.js /AsyncyPlugin.js
 
 ENTRYPOINT    ["postgraphile", \
                "-n", "0.0.0.0", \
                "-c", "postgres://postgres:@postgres:5432/postgres", \
                "--schema", "app_public", \
-               "--dynamic-json"]
+               "--dynamic-json", \
+               "--append-plugins", "/AsyncyPlugin.js"]


### PR DESCRIPTION
- [x] Uses the official PostGraphile docker image
- [x] Fixes `AppDns` being interpreted as the plural of `AppDn` 😳 
- [x] Removed the `ByFooIdAndBarId` from relations

---


Turns this:

<img width="482" alt="screenshot 2018-06-14 09 12 40" src="https://user-images.githubusercontent.com/129910/41397019-1c09e01a-6fb3-11e8-8d05-6f6bf77b0b3b.png">

---

Into this:

<img width="482" alt="screenshot 2018-06-14 09 18 46" src="https://user-images.githubusercontent.com/129910/41397281-05ad9aae-6fb4-11e8-962c-a83412a35d92.png">
